### PR TITLE
Adds the ability to report based on PR comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ async function renderComment(data) {
     try {
         const octokit = github.getOctokit(GITHUB_TOKEN, {log: console});
         const context = github.context;
-        
+        console.log(context)
         let markdown = await ejs.renderFile(`${__dirname}/templates/comment.md`, data);
         markdown
             .replace(/\%/g, '%25')

--- a/index.js
+++ b/index.js
@@ -66,11 +66,19 @@ async function renderComment(data) {
             .replace(/\n/g, '%0A')
             .replace(/\r/g, '%0D')    
 
+        const prNumber = GH_EVENT_NAME == 'pull_request'
+            ? context.payload.pull_request.number
+            : GH_EVENT_NAME == 'issue_comment' ?
+                context.payload.issue.number : null;
+        
+        if (!prNumber)
+            throw new Error('Incompatible event "' + GH_EVENT_NAME + '"');
+        
         //submit a comment
         await octokit.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            issue_number: context.payload.pull_request.number,
+            issue_number: prNumber,
             body: markdown
         });
     } catch (e) {

--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@ const METRICS = {
     "chromeUserTiming.CumulativeLayoutShift": "Cumulative Layout Shift",
 }
 
+const isReportSupported = () => GH_EVENT_NAME == 'pull_request' || GH_EVENT_NAME == 'issue_comment';
+
 const runTest = (wpt, url, options) => {
     // clone options object to avoid WPT wrapper issue
     let tempOptions = JSON.parse(JSON.stringify(options));
@@ -147,7 +149,7 @@ async function run() {
                                         + url +'. Full results at https://'
                                         + wpt.config.hostname + '/result/' + result.result.testId);
                             
-                            if (GH_EVENT_NAME == 'pull_request') {
+                            if (isReportSupported()) {
                                 let testResults = await retrieveResults(wpt, result.result.testId);
                                 collectData(testResults, runData);
                                 
@@ -167,7 +169,7 @@ async function run() {
                             core.info('Tests successfully completed for ' + url
                                 +'. Full results at ' + result.result.data.summary);
                             
-                            if (GH_EVENT_NAME == 'pull_request') {
+                            if (isReportSupported()) {
                                 let testResults = await retrieveResults(wpt, result.result.data.id);
                                 collectData(testResults, runData);
                             }
@@ -184,7 +186,7 @@ async function run() {
                 core.setFailed(`Action failed with error ${e}`);
             }
     })).then(() => {
-        if (GH_EVENT_NAME == 'pull_request') {
+        if (isReportSupported()) {
             renderComment(runData);
         }
     });

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ async function renderComment(data) {
     try {
         const octokit = github.getOctokit(GITHUB_TOKEN, {log: console});
         const context = github.context;
-        console.log(context)
+
         let markdown = await ejs.renderFile(`${__dirname}/templates/comment.md`, data);
         markdown
             .replace(/\%/g, '%25')


### PR DESCRIPTION
In combination with https://github.com/Khan/pull-request-comment-trigger you can completely customize when to run WPT on a PR.

Example:
```
on:
  pull_request:
    types: [opened]
  issue_comment:
    types: [created]

jobs:
  build:
    runs-on: ubuntu-latest
    name: WebPageTest Action
    steps:
      - uses: khan/pull-request-comment-trigger@master
        id: check
        with:
          trigger: '/wpt'
          reaction: rocket
          prefix_only: true
        env:
          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

      - name: Checkout
        if: steps.check.outputs.triggered == 'true'
        uses: actions/checkout@v2
        
      - name: WebPageTest
        if: steps.check.outputs.triggered == 'true'
        uses: productboardlabs/webpagetest-github-action@pr-comment-trigger
        with:
          apiKey: ${{ secrets.WEBPAGETEST_API }}
          urls: |
            http://example.com
          label: 'GitHub Action Test'
          wptOptions: 'wpt-options.json'
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          
```