### PR TITLE
Improve usefulness of error logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ const runTest = (wpt, url, options) => {
                     return reject(err);
                 }
             } catch (e) {
-                core.info(JSON.stringify(e));
+                core.info(e.statusText);
             }
         })
     });
@@ -82,7 +82,7 @@ async function renderComment(data) {
             body: markdown
         });
     } catch (e) {
-        core.setFailed(`Action failed with error ${JSON.stringify(e)}`);
+        core.setFailed(`Action failed with error ${e.statusText}`);
     }
 }
 function collectData(results, runData) {
@@ -186,12 +186,12 @@ async function run() {
                             return;
                         }
                     } catch (e) {
-                        core.setFailed(`Action failed with error ${JSON.stringify(e)}`);
+                        core.setFailed(`Action failed with error ${e.statusText}`);
                     }
                     
                 });
             } catch (e) {
-                core.setFailed(`Action failed with error ${JSON.stringify(e)}`);
+                core.setFailed(`Action failed with error ${e.statusText}`);
             }
     })).then(() => {
         if (isReportSupported()) {

--- a/index.js
+++ b/index.js
@@ -186,12 +186,12 @@ async function run() {
                             return;
                         }
                     } catch (e) {
-                        core.setFailed(`Action failed with error ${e.statusText}`);
+                        core.setFailed(`Action failed with error: ${e.statusText}`);
                     }
                     
                 });
             } catch (e) {
-                core.setFailed(`Action failed with error ${e.statusText}`);
+                core.setFailed(`Action failed with error: ${e.statusText}`);
             }
     })).then(() => {
         if (isReportSupported()) {

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ const runTest = (wpt, url, options) => {
                     return reject(err);
                 }
             } catch (e) {
-                core.info(e.statusText);
+                core.info(e.statusText || JSON.stringify(e));
             }
         })
     });
@@ -82,7 +82,7 @@ async function renderComment(data) {
             body: markdown
         });
     } catch (e) {
-        core.setFailed(`Action failed with error: ${e.statusText}`);
+        core.setFailed(`Action failed with error: ${e.statusText || JSON.stringify(e)}`);
     }
 }
 function collectData(results, runData) {
@@ -186,12 +186,12 @@ async function run() {
                             return;
                         }
                     } catch (e) {
-                        core.setFailed(`Action failed with error: ${e.statusText}`);
+                        core.setFailed(`Action failed with error: ${e.statusText || JSON.stringify(e)}`);
                     }
                     
                 });
             } catch (e) {
-                core.setFailed(`Action failed with error: ${e.statusText}`);
+                core.setFailed(`Action failed with error: ${e.statusText || JSON.stringify(e)}`);
             }
     })).then(() => {
         if (isReportSupported()) {

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ async function renderComment(data) {
             body: markdown
         });
     } catch (e) {
-        core.setFailed(`Action failed with error ${e.statusText}`);
+        core.setFailed(`Action failed with error: ${e.statusText}`);
     }
 }
 function collectData(results, runData) {

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ const runTest = (wpt, url, options) => {
                     return reject(err);
                 }
             } catch (e) {
-                core.info(e);
+                core.info(JSON.stringify(e));
             }
         })
     });
@@ -82,7 +82,7 @@ async function renderComment(data) {
             body: markdown
         });
     } catch (e) {
-        core.setFailed(`Action failed with error ${e}`);
+        core.setFailed(`Action failed with error ${JSON.stringify(e)}`);
     }
 }
 function collectData(results, runData) {
@@ -186,12 +186,12 @@ async function run() {
                             return;
                         }
                     } catch (e) {
-                        core.setFailed(`Action failed with error ${e}`);
+                        core.setFailed(`Action failed with error ${JSON.stringify(e)}`);
                     }
                     
                 });
             } catch (e) {
-                core.setFailed(`Action failed with error ${e}`);
+                core.setFailed(`Action failed with error ${JSON.stringify(e)}`);
             }
     })).then(() => {
         if (isReportSupported()) {


### PR DESCRIPTION
While using this Action many times we received generic errors like:
```
Error: Action failed with error [object Object]
```
This PR logs the actual error message from the Error object allowing users to see more helpful error messages. 

The error messages now look like:
```
Error: Action failed with error: The test request will exceed the remaining test balance for the given API key
```