### PR TITLE
Remove need to explicitly pass GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ jobs:
             https://example.com/
             https://example.com/about
           label: 'GitHub Action Test'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 3. Open a Pull Request. WebPageTest's GitHub Action will run in the background and post a comment on your PR.
@@ -89,7 +88,6 @@ jobs:
             https://example.com/about
           label: 'GitHub Action Test'
           budget: 'wpt-budget.json'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 And a `wpt-budget.json` file containing:
@@ -142,7 +140,6 @@ jobs:
           label: 'GitHub Action Test'
           budget: 'wpt-budget.json'
           wptOptions: 'wpt-options.json'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 _If you are testing against a Netlify deployment preview, it's important to note that the new collaborative features for their previews inject a full single-page application into your page, messing with any performance thresholds you might be trying to enforce. Add the following to your wptOptions JSON to make sure none of the extra code makes it into your test results_
@@ -179,7 +176,6 @@ jobs:
           label: 'GitHub Action Test'
           budget: 'wpt-budget.json'
           wptOptions: 'wpt-options.json'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 And a `wpt-options.json` file containing:

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,7 @@ inputs:
     required: false
   GITHUB_TOKEN:
     description: 'Secret GitHub Token (automatically provided by GitHub)'
+    default: ${{ github.token }}
 runs:
   using: 'node12'
   main: 'index.js'


### PR DESCRIPTION
This PR removes the need to explicitly pass a GitHub token as an action input. This helps a little to reduce the amount of configuration needed. You can still pass a different token explicitly if you want to.

GitHub's documentation on Actions doesn't really explain how to do this very clearly, but basically you have to set a default value for the token in `action.yml` that uses `${{ github.token }}`.

For example here are some examples of GitHub's own actions that use this approach:

- https://github.com/actions/checkout/blob/2541b1294d2704b0964813337f33b291d3f8596b/action.yml#L24
- https://github.com/actions/deploy-pages/blob/791c72a9c00a798aeb2a9e602f7ff515b5624bd5/action.yml#L14
- https://github.com/actions/stale/blob/33e37032bbf25592761040e9c94772c16e52e9a4/action.yml#L8